### PR TITLE
use the boost-defined imported targets instead of the deprecated variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,19 @@
 find_package(Boost 1.40 COMPONENTS system REQUIRED)
 find_package(Protobuf REQUIRED)
 
+if (TARGET Boost::system)
+    list(APPEND __boost_deps DEPS_TARGET Boost::system)
+else()
+    list(APPEND __boost_deps DEPS_PLAIN Boost)
+endif()
+
 protobuf_generate_cpp(msgs_SRCS msgs_HDR msgs.proto)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 rock_library(gazebo_thruster
     SOURCES GazeboThruster.cpp ${msgs_SRCS}
     HEADERS GazeboThruster.hpp
-    DEPS_PLAIN Boost
+    ${__boost_deps}
     DEPS_PKGCONFIG gazebo sdformat protobuf gazebo_underwater_msgs)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/msgs.pb.h


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/base-cmake/pull/59